### PR TITLE
nit: Removed Body Parser as an external package

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "body-parser": "^1.19.0",
     "ejs": "^3.0.1",
     "express": "^4.17.1",
     "knex": "^0.20.11",

--- a/server.js
+++ b/server.js
@@ -1,5 +1,4 @@
 const express = require("express");
-const bodyParser = require("body-parser");
 const kenx = require("knex");
 
 const db = kenx({
@@ -13,8 +12,8 @@ const db = kenx({
 });
 
 const app = express();
-app.use(bodyParser.urlencoded({ extended: true }));
-app.use(bodyParser.json());
+app.use(express.urlencoded({ extended: true }));
+app.use(express.json());
 app.set("view engine", "ejs");
 
 app.use(express.static("public"));


### PR DESCRIPTION
Express 4 now has most of body-parser functionalities as described here: https://expressjs.com/en/guide/migrating-4.html I just thought I should remove that :) 

